### PR TITLE
Revert "Update scala-library, scala-reflect to 2.13.6"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val SCALA_2_12          = "2.12.12"
-val SCALA_2_13          = "2.13.6"
+val SCALA_2_13          = "2.13.4"
 val targetScalaVersions = SCALA_2_13 :: Nil
 
 val AIRFRAME_VERSION    = "21.9.0"


### PR DESCRIPTION
Reverts wvlet/querybase#130

semanticdb is not yet ready for Scala 2.13.6